### PR TITLE
Updates for rubygems package

### DIFF
--- a/rubygems/rubygems.nuspec
+++ b/rubygems/rubygems.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>rubygems</id>
@@ -7,19 +7,19 @@
     <authors>Nick Quaranto</authors>
     <owners>Carolyn Van Slyck</owners>
     <summary>The Ruby community's gem hosting service.</summary>
-    <description>The Ruby community's gem hosting service.</description>
+    <description>This package updates RubyGems to the latest version - the current RubyInstaller packages have a broken version that doesn't work with the TLS certificate that the rubygems.org site uses, which means that all gem installs fail with SSL errors.  Once this is installed, everything gem-related will work with no extra effort required.</description>
     <projectUrl>https://rubygems.org</projectUrl>
-    <tags>rubygems ruby</tags>
-    <copyright></copyright>
+    <tags>ruby rubygems</tags>
+    <copyright>Nick Quaranto</copyright>
     <licenseUrl>https://raw.github.com/rubygems/rubygems.org/master/MIT-LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.github.com/carolynvs/chocolatey-packages/master/rubygems/rubygems.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/carolynvs/chocolatey-packages/32133c44363e8fe1c65b1dc9fdb8ae61ebdd5a4d/rubygems/rubygems.png</iconUrl>
+    <releaseNotes/>
     <dependencies>
-      <dependency id="ruby" />
+      <dependency id="ruby"/>
     </dependencies>
-    <releaseNotes></releaseNotes>
   </metadata>
   <files>
-    <file src="tools\**" target="tools" />
+    <file src="tools\**" target="tools"/>
   </files>
 </package>

--- a/rubygems/tools/chocolateyInstall.ps1
+++ b/rubygems/tools/chocolateyInstall.ps1
@@ -1,26 +1,21 @@
-﻿$pwd = Get-Location
-$packageName = 'rubygems'
-$version = '2.4.6'
-$zipName = "rubygems-$version.zip"
-$url = "http://production.cf.rubygems.org/rubygems/$zipName"
-$validExitCodes = @(0)
-$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-$zipPath = Join-Path $scriptPath $zipName
-$setupDir = Join-Path $scriptPath "rubygems-$version"
-
-try {
-
-  Get-ChocolateyWebFile "$packageName" "$zipPath" "$url"
-  Get-ChocolateyUnzip "$zipPath" "$scriptPath"
-  
-  Set-Location $setupDir
-  Start-ChocolateyProcessAsAdmin 'setup.rb' 'ruby' -validExitCodes $validExitCodes
-
-  Write-ChocolateySuccess "$packageName"
-} catch {
-  Write-ChocolateyFailure "$packageName" "$($_.Exception.Message)"
-  throw
+﻿Update-SessionEnvironment # If ruby was just installed, it won't be on the path yet, unless we do this.
+$rubyFound = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+If (! $rubyFound) {
+  Write-Host "Ruby not found!  Install with 'choco install ruby', or add ruby to your path if already installed."
+  Throw "Ruby not found!"
 }
-finally {
-  Set-Location $pwd
+
+$dir = Join-Path $env:chocolateyPackageFolder 'tools'
+$filename = 'rubygems-update-2.4.6.gem'
+$url = "https://rubygems.org/downloads/$filename"
+$gemrc = Join-Path $env:userprofile '.gemrc'
+
+If (! (Test-Path $gemrc)) {
+  "gem: --no-document --quiet" | Out-File -Encoding ASCII $gemrc
+  Write-Host "Setting gem installations to skip documentation and produce minimal output - if you need ri/rdoc available locally, please edit or remove $gemrc"
 }
+
+Get-ChocolateyWebFile 'rubygems' "$dir\$filename" $url
+Set-Location $dir
+& gem install -q $filename
+& update_rubygems.bat --no-document | Out-Null

--- a/rubygems/tools/chocolateyUninstall.ps1
+++ b/rubygems/tools/chocolateyUninstall.ps1
@@ -1,1 +1,1 @@
-﻿Start-ChocolateyProcessAsAdmin 'uninstall -x rubygems-update' 'gem'
+﻿& gem uninstall -x rubygems-update

--- a/rubygems/tools/chocolateyUninstall.ps1
+++ b/rubygems/tools/chocolateyUninstall.ps1
@@ -1,0 +1,1 @@
+﻿Start-ChocolateyProcessAsAdmin 'uninstall -x rubygems-update' 'gem'


### PR DESCRIPTION
Hi Carolyn,

  I've been using your rubygems 2.4.6 package on a few machines, and found that I had to run update_rubygems.bat manually to get it to work.  So I made a few alterations and it runs fine for me now, along with setting some sensible .gemrc defaults, CDN for the icon, etc.

  I saw Anthony's comments and they're not really relevant to this version.  The push/pop location stuff doesn't actually matter as every chocolatey installation is run in an individual powershell process, so the location is reset after the script is run anyway.  It also now downloads the .gem file (over https) and gem installs that, which seems to be the recommended approach over the zip/setup.rb method.

  This is also why I put the update-sessionenvironment call in at the start, as without this a choco install -y rubygems in powershell installs ruby and then fails with a 'ruby not found' error, as the path hasn't updated in the shell that launches the installer scripts.

  Anyway, hope there's something here of use to you!

Edmund
